### PR TITLE
Add another runtime check

### DIFF
--- a/nvidia-docker-host/roles/nvidiadocker/tasks/main.yml
+++ b/nvidia-docker-host/roles/nvidiadocker/tasks/main.yml
@@ -7,6 +7,9 @@
   become: yes
   become_user: root
 
+- name: Run the nvidia-smi demo
+  command: nvidia-docker run nvidia/cuda:7.5 nvidia-smi
+
 - name: Run the cljs convolution demo
   command: nvidia-docker run -d --name cljstest -p 80:3001 graphistry/cljs:1.0
 


### PR DESCRIPTION
Run nvidia-smi on a stock nvidia/cuda container, to test on zero Graphistry-specific components before proceeding.
