### PR TITLE
Run the cljs test, not the convolution demo.

### DIFF
--- a/nvidia-docker-host/roles/nvidiadocker/tasks/main.yml
+++ b/nvidia-docker-host/roles/nvidiadocker/tasks/main.yml
@@ -7,14 +7,5 @@
   become: yes
   become_user: root
 
-- name: Run the cljs convolution demo
-  command: nvidia-docker run -d --name cljstest -p 80:3001 graphistry/cljs:1.0.1
-
-- name: Get the opencl version
-  command: bash -c "curl 'localhost/?mode=opencl' | sed -E -e 's/[0-9]+ ms /0 ms/' | sha256sum       > /tmp/sha"
-
-- name: Check against the straight JS version
-  command: bash -c "curl 'localhost/'             | sed -E -e 's/[0-9]+ ms /0 ms/' | sha256sum --check /tmp/sha"
-
-- name: Stop the cljs demo
-  command: docker rm -f cljstest
+- name: Run the cljs test
+  command: nvidia-docker run graphistry/cljs:1.1 npm test


### PR DESCRIPTION
The red panda and its outline is obviously delightful, but the simpler test of CLjs addition in the container reduces dependencies on networking stacks, hash functions, weird regexes, file system temp directories, et cetera
